### PR TITLE
Fix default validation rule language for max to be more accurate.

### DIFF
--- a/src/libs/rules.js
+++ b/src/libs/rules.js
@@ -140,19 +140,19 @@ export default {
   /**
    * Check the maximum value of a particular.
    */
-  max: function ({ value }, minimum = 10, force) {
+  max: function ({ value }, maximum = 10, force) {
     return Promise.resolve((() => {
       if (Array.isArray(value)) {
-        minimum = !isNaN(minimum) ? Number(minimum) : minimum
-        return value.length <= minimum
+        maximum = !isNaN(maximum) ? Number(maximum) : maximum
+        return value.length <= maximum
       }
       if ((!isNaN(value) && force !== 'length') || force === 'value') {
         value = !isNaN(value) ? Number(value) : value
-        return value <= minimum
+        return value <= maximum
       }
       if (typeof value === 'string' || (force === 'length')) {
         value = !isNaN(value) ? value.toString() : value
-        return value.length <= minimum
+        return value.length <= maximum
       }
       return false
     })())

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -115,9 +115,9 @@ export default {
     }
     const force = Array.isArray(args) && args[1] ? args[1] : false
     if ((!isNaN(value) && force !== 'length') || force === 'value') {
-      return `${s(name)} must be less than ${args[0]}.`
+      return `${s(name)} must be less than or equal to ${args[0]}.`
     }
-    return `${s(name)} must be less than ${args[0]} characters long.`
+    return `${s(name)} must be less than or equal to ${args[0]} characters long.`
   },
 
   /**


### PR DESCRIPTION
Correct “max” variable name in max validation rule.