### PR TITLE
Create locales/de.js

### DIFF
--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -1,0 +1,173 @@
+import { sentence as s } from '../libs/utils'
+/**
+ * Validation error message generators.
+ */
+export default {
+
+  /**
+   * Valid accepted value.
+   */
+  accepted: function ({ name }) {
+    return `Sie müssen ${name} zustimmen.`
+  },
+
+  /**
+   * The date is not after.
+   */
+  after: function ({ name, args }) {
+    if (Array.isArray(args) && args.length) {
+      return `${s(name)} muss auf ${args[0]} folgen.`
+    }
+    return `${s(name)} muss ein späteres Datum sein.`
+  },
+
+  /**
+   * The value is not a letter.
+   */
+  alpha: function ({ name }) {
+    return `${s(name)} darf nur Buchstaben enthalten.`
+  },
+
+  /**
+   * Rule: checks if the value is alpha numeric
+   */
+  alphanumeric: function ({ name }) {
+    return `${s(name)} darf nur Buchstaben und Zahlen enthalten.`
+  },
+
+  /**
+   * The date is not before.
+   */
+  before: function ({ name, args }) {
+    if (Array.isArray(args) && args.length) {
+      return `${s(name)} muss vor ${args[0]} sein.`
+    }
+    return `${s(name)} muss ein früheres Datum sein.`
+  },
+
+  /**
+   * The value is not between two numbers or lengths
+   */
+  between: function ({ name, value, args }) {
+    if (!isNaN(value)) {
+      return `${s(name)} muss zwischen ${args[0]} und ${args[1]}.`
+    }
+    return `${s(name)} muss zwischen ${args[0]} und ${args[1]} Zeichen lang sein.`
+  },
+
+  /**
+   * The confirmation field does not match
+   */
+  confirm: function ({ name, args }) {
+    return `${s(name)} stimmt nicht überein.`
+  },
+
+  /**
+   * Is not a valid date.
+   */
+  date: function ({ name, args }) {
+    if (Array.isArray(args) && args.length) {
+      return `${s(name)} ist nicht korrekt, bitte das Format ${args[0]} benutzen.`
+    }
+    return `${s(name)} ist kein gültiges Datum.`
+  },
+
+  /**
+   * The default render method for error messages.
+   */
+  default: function ({ name }) {
+    return `Das Feld hat einen Fehler.`
+  },
+
+  /**
+   * Is not a valid email address.
+   */
+  email: function ({ name, value }) {
+    if (!value) {
+      return 'Bitte eine gültige E-Mail-Adresse eingeben.'
+    }
+    return `“${value}” ist keine gültige E-Mail-Adresse.`
+  },
+
+  /**
+   * Value is an allowed value.
+   */
+  in: function ({ name, value }) {
+    if (typeof value === 'string' && value) {
+      return `“${s(value)}” ist kein gültiger Wert für ${name}.`
+    }
+    return `Dies ist kein gültiger Wert für ${name}.`
+  },
+
+  /**
+   * Value is not a match.
+   */
+  matches: function ({ name }) {
+    return `${s(name)} ist kein gültiger Wert.`
+  },
+
+  /**
+   * The maximum value allowed.
+   */
+  max: function ({ name, value, args }) {
+    if (Array.isArray(value)) {
+      return `Es dürfen nur ${args[0]} ${name} ausgewählt werden.`
+    }
+    const force = Array.isArray(args) && args[1] ? args[1] : false
+    if ((!isNaN(value) && force !== 'length') || force === 'value') {
+      return `${s(name)} muss kleiner oder gleich ${args[0]} sein.`
+    }
+    return `${s(name)} muss ${args[0]} oder weniger Zeichen lang sein.`
+  },
+
+  /**
+   * The (field-level) error message for mime errors.
+   */
+  mime: function ({ name, args }) {
+    return `${s(name)} muss den Typ ${args[0] || 'Keine Dateien erlaubt'} haben.`
+  },
+
+  /**
+   * The maximum value allowed.
+   */
+  min: function ({ name, value, args }) {
+    if (Array.isArray(value)) {
+      return `Es müssen mindestens ${args[0]} ${name} ausgewählt werden.`
+    }
+    const force = Array.isArray(args) && args[1] ? args[1] : false
+    if ((!isNaN(value) && force !== 'length') || force === 'value') {
+      return `${s(name)} muss größer als ${args[0]} sein.`
+    }
+    return `${s(name)} must ${args[0]} oder mehr Zeichen lang sein.`
+  },
+
+  /**
+   * The field is not an allowed value
+   */
+  not: function ({ name, value }) {
+    return `“${value}” ist kein erlaubter Wert für ${name}.`
+  },
+
+  /**
+   * The field is not a number
+   */
+  number: function ({ name }) {
+    return `${s(name)} muss eine Zahl sein.`
+  },
+
+  /**
+   * Required field.
+   */
+  required: function ({ name }) {
+    return `${s(name)} ist ein Pflichtfeld.`
+  },
+
+  /**
+   * Value is not a url.
+   */
+  url: function ({ name }) {
+    return `${s(name)} muss eine gültige URL sein.`
+  }
+}
+
+

--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -8,7 +8,7 @@ export default {
    * Valid accepted value.
    */
   accepted: function ({ name }) {
-    return `Sie müssen ${name} zustimmen.`
+    return `${name} erfordert Zustimmung.`
   },
 
   /**
@@ -86,15 +86,26 @@ export default {
     if (!value) {
       return 'Bitte eine gültige E-Mail-Adresse eingeben.'
     }
-    return `“${value}” ist keine gültige E-Mail-Adresse.`
+    return `„${value}“ ist keine gültige E-Mail-Adresse.`
   },
+
+   /**
+   * Ends with specified value
+   */
+  endsWith: function ({ name, value }) {
+    if (!value) {
+      return `Dieses Feld endet nicht mit einem gültigen Wert`
+    }
+    return `„${value}” endet nicht mit einem gültigen Wert.`
+  },
+
 
   /**
    * Value is an allowed value.
    */
   in: function ({ name, value }) {
     if (typeof value === 'string' && value) {
-      return `“${s(value)}” ist kein gültiger Wert für ${name}.`
+      return `„${s(value)}“ ist kein gültiger Wert für ${name}.`
     }
     return `Dies ist kein gültiger Wert für ${name}.`
   },
@@ -145,7 +156,7 @@ export default {
    * The field is not an allowed value
    */
   not: function ({ name, value }) {
-    return `“${value}” ist kein erlaubter Wert für ${name}.`
+    return `„${value}“ ist kein erlaubter Wert für ${name}.`
   },
 
   /**
@@ -162,6 +173,16 @@ export default {
     return `${s(name)} ist ein Pflichtfeld.`
   },
 
+  /**
+   * Starts with specified value
+   */
+  startsWith: function ({ name, value }) {
+    if (!value) {
+      return `Dieses Feld beginnt nicht mit einem gültigen Wert`
+    }
+    return `„${value}” beginnt nicht mit einem gültigen Wert`
+  },
+  
   /**
    * Value is not a url.
    */


### PR DESCRIPTION
Initial validation translation for German

A few notes:
* I feel like a few of the phrases I chose are a bit awkward, but I did not know how to better work those into the message-framework.
* I used passive voice everywhere to make it more generally usable instead of specifically using Du/Sie (informal/formal). It might make sense for German to have 2 or 3 translations according to the site’s standards.
* The `mime` validation message is horrible in case no types are allowed. I had no idea how to fix that.