### PR TITLE
Hide overflow of file names (and apply ellipsis)

### DIFF
--- a/themes/snow/_inputs.scss
+++ b/themes/snow/_inputs.scss
@@ -502,6 +502,9 @@
         padding-left: 1.5em;
         padding-right: 2em;
         max-width: 100%;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
 
         &::before {
           position: absolute;


### PR DESCRIPTION
I realised that no overflow protection is being applied on `input[type=file]` when file name is bigger than the container.

### Current behaviour
![current](https://user-images.githubusercontent.com/741969/76144336-e47f6280-605d-11ea-989a-3a1609ea8fc0.png)

### Proposal
![proposal](https://user-images.githubusercontent.com/741969/76144338-e812e980-605d-11ea-91f6-299a5a248e23.png)


