### PR TITLE
Updates vue-formulate-i18n to 1.1.0 which includes Portuguese

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,14 @@ The syntax is what developers would expect:
 
 ✓ Create any input element with a single component<br>
 ✓ Supports Vue `v-model` [binding](https://vueformulate.com/guide/#model-binding)<br>
-✓ [Re-populate an entire form](https://vueformulate.com//guide/forms/#setting-initial-values) from a single object<br>
-✓ [Generate a form](https://vueformulate.com//guide/forms/#generating-forms) using json<br>
+✓ [Re-populate an entire form](https://vueformulate.com/guide/forms/#setting-initial-values) from a single object<br>
+✓ [Generate a form](https://vueformulate.com/guide/forms/#generating-forms) using json<br>
 ✓ Easy to add field labels<br>
 ✓ Easy to add help text<br>
-✓ Easy to add [form validation](https://vueformulate.com//guide/validation)<br>
-✓ Easy to add [custom validation](https://vueformulate.com//guide/validation/#custom-validation-rules) rules<br>
-✓ Easy to modify [validation messages](https://vueformulate.com//guide/validation/#customize-validation-messages)<br>
-✓ Easy to add [custom inputs](https://vueformulate.com//guide/custom-inputs)
+✓ Easy to add [form validation](https://vueformulate.com/guide/validation)<br>
+✓ Easy to add [custom validation](https://vueformulate.com/guide/validation/#custom-validation-rules) rules<br>
+✓ Easy to modify [validation messages](https://vueformulate.com/guide/validation/#customize-validation-messages)<br>
+✓ Easy to add [custom inputs](https://vueformulate.com/guide/custom-inputs)<br>
+✓ Backend response [error handling](https://vueformulate.com/guide/forms/error-handling)
 
 There's a lot more available to read at the [documentation website](https://vueformulate.com).

--- a/package-lock.json
+++ b/package-lock.json
@@ -2770,9 +2770,9 @@
       }
     },
     "@braid/vue-formulate-i18n": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@braid/vue-formulate-i18n/-/vue-formulate-i18n-1.0.3.tgz",
-      "integrity": "sha512-HkF8S+u4g/lJn4m6qlQpHi63GuQERTovbW7cAsQtxcQF1xHUSviMYC3NPVfRlzOOrUT3eoolTdiF5yZ0DCj9sQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@braid/vue-formulate-i18n/-/vue-formulate-i18n-1.1.0.tgz",
+      "integrity": "sha512-DcLSYP9cs7q0RvmxkoQy5EGvk1nvir3USEo55tUrQX0QBy05LojZDT9o2UCdw5Dr5hAAsxQ7HurJjzRIfN8Kvw==",
       "requires": {
         "@rollup/plugin-buble": "^0.21.1",
         "@rollup/plugin-commonjs": "^11.0.2"

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "watch": "^1.0.2"
   },
   "dependencies": {
-    "@braid/vue-formulate-i18n": "^1.0.3",
+    "@braid/vue-formulate-i18n": "^1.1.0",
     "is-plain-object": "^3.0.0",
     "is-url": "^1.2.4",
     "nanoid": "^2.1.11"


### PR DESCRIPTION
In this PR:

- `vue-formulate-i18n` was updated to 1.1.0 which includes Portuguese locale (pt). Thanks to @hmaesta, this is a version bump