### PR TITLE
WIP: Accessibility: Add `aria-describedby` if help text or errors are given

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build:umd": "rollup --config build/rollup.config.js --format umd --file dist/formulate.umd.js",
     "build:iife": "rollup --config build/rollup.iife.config.js --format iife --file dist/formulate.min.js",
     "build:css": "node-sass themes/snow/snow.scss dist/snow.css && postcss --use autoprefixer -b '> 2%' < dist/snow.css | postcss --no-map --use cssnano > dist/snow.min.css",
+    "lint": "eslint src/**/*.{js,vue} --fix",
     "test": "NODE_ENV=test jest --config test/jest.conf.js",
     "test:watch": "NODE_ENV=test jest --config test/jest.conf.js --watch",
     "test:coverage": "NODE_ENV=test jest --config test/jest.conf.js --coverage",

--- a/src/FormulateErrors.vue
+++ b/src/FormulateErrors.vue
@@ -2,6 +2,7 @@
   <ul
     v-if="visibleErrors.length"
     :class="`formulate-${type}-errors`"
+    data-test="formulate-errors"
   >
     <li
       v-for="error in visibleErrors"

--- a/src/FormulateInput.vue
+++ b/src/FormulateInput.vue
@@ -43,7 +43,9 @@
     </div>
     <div
       v-if="help"
+      :id="helpId"
       class="formulate-input-help"
+      data-test="formulate-input-help"
       v-text="help"
     />
     <FormulateErrors
@@ -220,6 +222,16 @@ export default {
         messages[snakeToCamel(key)] = this.validationMessages[key]
       })
       return messages
+    },
+    helpId () {
+      const id = this.id || this.defaultId
+
+      return `${id}-help-text`
+    },
+    errorId () {
+      const id = this.id || this.defaultId
+
+      return `${id}-errors`
     }
   },
   watch: {

--- a/src/inputs/FormulateInputText.vue
+++ b/src/inputs/FormulateInputText.vue
@@ -7,6 +7,7 @@
       v-model="context.model"
       :type="type"
       v-bind="attributes"
+      data-test="formulate-input-text"
       @blur="context.blurHandler"
     >
   </div>

--- a/src/libs/context.js
+++ b/src/libs/context.js
@@ -78,11 +78,17 @@ function typeContext () {
  */
 function elementAttributes () {
   const attrs = Object.assign({}, this.localAttributes)
+
   if (this.id) {
     attrs.id = this.id
   } else {
     attrs.id = this.defaultId
   }
+
+  if (this.help) {
+    attrs['aria-describedby'] = this.id ? `${this.id}-help-text` : `${this.defaultId}-help-text`
+  }
+
   return attrs
 }
 

--- a/test/unit/FormulateInput.test.js
+++ b/test/unit/FormulateInput.test.js
@@ -131,4 +131,23 @@ describe('FormulateInput', () => {
     await flushPromises()
     expect(wrapper.contains(FormulateInputBox)).toBe(true)
   })
+    it('links errors with `aria-describedby`', async () => {
+      const wrapper = mount(FormulateInput, {
+        propsData: {
+          type: 'text',
+          validation: 'required|globalRule',
+          errorBehavior: 'live',
+          value: 'bar',
+          help: 'Some help text'
+        }
+      })
+
+      await flushPromises()
+
+      const text = wrapper.find('[data-test="formulate-input-text"]')
+      const errors = wrapper.find('[data-test="formulate-errors"]')
+      const errorsId = errors.attributes('id')
+
+      expect(text.attributes('aria-describedby')).toBe(errorsId);
+    });
 })

--- a/test/unit/FormulateInput.test.js
+++ b/test/unit/FormulateInput.test.js
@@ -26,94 +26,108 @@ Vue.use(Formulate, {
 
 describe('FormulateInput', () => {
   it('allows custom field-rule level validation strings', async () => {
-    const wrapper = mount(FormulateInput, { propsData: {
-      type: 'text',
-      validation: 'required|in:abcdef',
-      validationMessages: {in: 'the value was different than expected'},
-      errorBehavior: 'live',
-      value: 'other value'
-    } })
+    const wrapper = mount(FormulateInput, {
+      propsData: {
+        type: 'text',
+        validation: 'required|in:abcdef',
+        validationMessages: { in: 'the value was different than expected' },
+        errorBehavior: 'live',
+        value: 'other value'
+      }
+    })
     await flushPromises()
     expect(wrapper.find('.formulate-input-error').text()).toBe('the value was different than expected')
   })
 
   it('allows custom field-rule level validation functions', async () => {
-    const wrapper = mount(FormulateInput, { propsData: {
-      type: 'text',
-      validation: 'required|in:abcdef',
-      validationMessages: { in: ({ value }) => `The string ${value} is not correct.` },
-      errorBehavior: 'live',
-      value: 'other value'
-    } })
+    const wrapper = mount(FormulateInput, {
+      propsData: {
+        type: 'text',
+        validation: 'required|in:abcdef',
+        validationMessages: { in: ({ value }) => `The string ${value} is not correct.` },
+        errorBehavior: 'live',
+        value: 'other value'
+      }
+    })
     await flushPromises()
     expect(wrapper.find('.formulate-input-error').text()).toBe('The string other value is not correct.')
   })
 
   it('uses globally overridden validation messages', async () => {
-    const wrapper = mount(FormulateInput, { propsData: {
-      type: 'text',
-      validation: 'required|email',
-      errorBehavior: 'live',
-      value: 'wrong email'
-    } })
+    const wrapper = mount(FormulateInput, {
+      propsData: {
+        type: 'text',
+        validation: 'required|email',
+        errorBehavior: 'live',
+        value: 'wrong email'
+      }
+    })
     await flushPromises()
     expect(wrapper.find('.formulate-input-error').text()).toBe('Super invalid email: wrong email')
   })
 
   it('uses custom async validation rules on defined on the field', async () => {
-    const wrapper = mount(FormulateInput, { propsData: {
-      type: 'text',
-      validation: 'required|foobar',
-      validationMessages: {
-        foobar: 'failed the foobar check'
-      },
-      validationRules: {
-        foobar: async ({ value }) => value === 'foo'
-      },
-      validation: 'required|foobar',
-      errorBehavior: 'live',
-      value: 'bar'
-    } })
+    const wrapper = mount(FormulateInput, {
+      propsData: {
+        type: 'text',
+        validation: 'required|foobar',
+        validationMessages: {
+          foobar: 'failed the foobar check'
+        },
+        validationRules: {
+          foobar: async ({ value }) => value === 'foo'
+        },
+        validation: 'required|foobar',
+        errorBehavior: 'live',
+        value: 'bar'
+      }
+    })
     await flushPromises()
     expect(wrapper.find('.formulate-input-error').text()).toBe('failed the foobar check')
   })
 
   it('uses custom sync validation rules on defined on the field', async () => {
-    const wrapper = mount(FormulateInput, { propsData: {
-      type: 'text',
-      validation: 'required|foobar',
-      validationMessages: {
-        foobar: 'failed the foobar check'
-      },
-      validationRules: {
-        foobar: ({ value }) => value === 'foo'
-      },
-      validation: 'required|foobar',
-      errorBehavior: 'live',
-      value: 'bar'
-    } })
+    const wrapper = mount(FormulateInput, {
+      propsData: {
+        type: 'text',
+        validation: 'required|foobar',
+        validationMessages: {
+          foobar: 'failed the foobar check'
+        },
+        validationRules: {
+          foobar: ({ value }) => value === 'foo'
+        },
+        validation: 'required|foobar',
+        errorBehavior: 'live',
+        value: 'bar'
+      }
+    })
     await flushPromises()
     expect(wrapper.find('.formulate-input-error').text()).toBe('failed the foobar check')
   })
 
   it('uses global custom validation rules', async () => {
-    const wrapper = mount(FormulateInput, { propsData: {
-      type: 'text',
-      validation: 'required|globalRule',
-      errorBehavior: 'live',
-      value: 'bar'
-    } })
+    const wrapper = mount(FormulateInput, {
+      propsData: {
+        type: 'text',
+        validation: 'required|globalRule',
+        errorBehavior: 'live',
+        value: 'bar'
+      }
+    })
     await flushPromises()
     expect(globalRule.mock.calls.length).toBe(1)
   })
 
   it('can extend its standard library of inputs', async () => {
-    const wrapper = mount(FormulateInput, { propsData: {
-      type: 'special',
-      validation: 'required',
-      errorBehavior: 'live',
-      value: 'bar'
-    } })
+    const wrapper = mount(FormulateInput, {
+      propsData: {
+        type: 'special',
+        validation: 'required',
+        errorBehavior: 'live',
+        value: 'bar'
+      }
+    })
     await flushPromises()
     expect(wrapper.contains(FormulateInputBox)).toBe(true)
   })

--- a/test/unit/FormulateInput.test.js
+++ b/test/unit/FormulateInput.test.js
@@ -131,6 +131,28 @@ describe('FormulateInput', () => {
     await flushPromises()
     expect(wrapper.contains(FormulateInputBox)).toBe(true)
   })
+
+  describe('Attributes', () => {
+    it('links help text with `aria-describedby`', async () => {
+      const wrapper = mount(FormulateInput, {
+        propsData: {
+          type: 'text',
+          validation: 'required|globalRule',
+          errorBehavior: 'live',
+          value: 'bar',
+          help: 'Some help text'
+        }
+      })
+
+      await flushPromises()
+
+      const text = wrapper.find('[data-test="formulate-input-text"]')
+      const help = wrapper.find('[data-test="formulate-input-help"]')
+      const helpId = help.attributes('id')
+
+      expect(text.attributes('aria-describedby')).toBe(helpId);
+    });
+
     it('links errors with `aria-describedby`', async () => {
       const wrapper = mount(FormulateInput, {
         propsData: {
@@ -150,4 +172,5 @@ describe('FormulateInput', () => {
 
       expect(text.attributes('aria-describedby')).toBe(errorsId);
     });
+  });
 })


### PR DESCRIPTION
Hey,

here’s a first draft to fix #30 

I got it working for text-like inputs and the help text. But I’m having kind of a hard time to get it to work for the errors, as the `visibleErrors` are determined in FormulateErrors.vue and FormulateInput (which has to orchestrate all the attributes) does not know about it. 

There are a couple of ways that come to mind how to solve this. Emitting an event in a watcher if the length of `visibleErrors` changes from 0 to >0. Or moving the visibility logic up to FormulateInput. Or maybe setting a property on `this.$formulate`?
Do you have any preferred way?

Regarding label: Changing label to be a required prop would be a breaking change and should probably not be introduced in a minor release. I would a `console.warn` call to warn implementors that they _should_ add a label if none is given. It could be changed to be required in 3.0.

Sorry for keeping you waiting for so long!

Oscar