### PR TITLE
Bumps vue-formulate-i18n to 1.7.0 with Russian support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@braid/vue-formulate",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1173,9 +1173,9 @@
       "dev": true
     },
     "@braid/vue-formulate-i18n": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@braid/vue-formulate-i18n/-/vue-formulate-i18n-1.6.2.tgz",
-      "integrity": "sha512-/a9WMJCskMAOZrfYRmWBIO7wvwp1UpVtViNlF0QFpdJb6SCuvmOWt4Bt/j+QePEP84cKnGfkTinOjuijfAb/Ew=="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@braid/vue-formulate-i18n/-/vue-formulate-i18n-1.7.0.tgz",
+      "integrity": "sha512-yyF4SpH+frMaQ3Xe+OaEvkrTpDfj1nrGLA6oNWeDyJ/11UIyrcZ5Wp6Z6fGV3D1sKOS+o9XrVeaf2t4ZXpDugw=="
     },
     "@hapi/address": {
       "version": "2.1.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "watch": "^1.0.2"
   },
   "dependencies": {
-    "@braid/vue-formulate-i18n": "^1.6.2",
+    "@braid/vue-formulate-i18n": "^1.7.0",
     "is-plain-object": "^3.0.0",
     "is-url": "^1.2.4",
     "nanoid": "^2.1.11"


### PR DESCRIPTION
In this PR:

- Bumps `vue-formualte-i18n` to 1.7.0, which includes Russian support 🇷🇺.