### PR TITLE
Adds the ability to generate recursive forms

### DIFF
--- a/src/Formulate.js
+++ b/src/Formulate.js
@@ -7,6 +7,7 @@ import isPlainObject from 'is-plain-object'
 import { en } from '@braid/vue-formulate-i18n'
 import fauxUploader from './libs/faux-uploader'
 import FormulateSlot from './FormulateSlot'
+import FormulateSchema from './FormulateSchema'
 import FormulateForm from './FormulateForm.vue'
 import FormulateInput from './FormulateInput.vue'
 import FormulateErrors from './FormulateErrors.vue'
@@ -43,6 +44,7 @@ class Formulate {
         FormulateLabel,
         FormulateInput,
         FormulateErrors,
+        FormulateSchema,
         FormulateAddMore,
         FormulateGrouping,
         FormulateInputBox,

--- a/src/FormulateForm.vue
+++ b/src/FormulateForm.vue
@@ -3,6 +3,10 @@
     :class="classes"
     @submit.prevent="formSubmitted"
   >
+    <FormulateSchema
+      v-if="schema"
+      :schema="schema"
+    />
     <FormulateErrors
       v-if="!hasFormErrorObservers"
       :context="formContext"
@@ -50,6 +54,10 @@ export default {
     formErrors: {
       type: Array,
       default: () => ([])
+    },
+    schema: {
+      type: [Object, Boolean],
+      default: false
     }
   },
   data () {

--- a/src/FormulateSchema.vue
+++ b/src/FormulateSchema.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="formulate-schema-group">
+    <component
+      :is="item.component"
+      v-for="item in items"
+      :key="item.key"
+      v-bind="item.attrs"
+    >
+      <FormulateSchema
+        v-if="item.children"
+        :schema="item.children"
+      />
+    </component>
+  </div>
+</template>
+
+<script>
+import { createItem } from './libs/utils'
+
+export default {
+  props: {
+    schema: {
+      type: Array,
+      required: true
+    }
+  },
+  computed: {
+    items () {
+      return this.schema.map(item => createItem(item))
+    }
+  }
+}
+</script>

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -303,3 +303,22 @@ export function isEmpty (value) {
     )
   )
 }
+
+/**
+ * Given an object and an index, complete an object for schema-generation.
+ * @param {object} item
+ * @param {int} index
+ */
+export function createItem (item, index) {
+  if (item && typeof item === 'object' && !Array.isArray(item)) {
+    const { children = null, component = 'FormulateInput', depth = 1, ...attrs } = item
+    const type = component === 'FormulateInput' ? (attrs.type || 'text') : ''
+    const name = attrs.name || type || 'el'
+    const key = attrs.id || `${name}-${depth}-${index}`
+    const els = Array.isArray(children)
+      ? children.map(child => Object.assign(child, { depth: depth + 1 }))
+      : false
+    return Object.assign({ key, depth, attrs, component }, els ? { children: els } : {})
+  }
+  return null
+}

--- a/test/unit/Formulate.test.js
+++ b/test/unit/Formulate.test.js
@@ -68,6 +68,7 @@ describe('Formulate', () => {
       'FormulateLabel',
       'FormulateInput',
       'FormulateErrors',
+      'FormulateSchema',
       'FormulateAddMore',
       'FormulateGrouping',
       'FormulateInputBox',

--- a/test/unit/FormulateSchema.test.js
+++ b/test/unit/FormulateSchema.test.js
@@ -1,0 +1,43 @@
+import Vue from 'vue'
+import flushPromises from 'flush-promises'
+import { mount } from '@vue/test-utils'
+import Formulate from '@/Formulate.js'
+import FormulateSchema from '@/FormulateSchema.vue'
+import FormulateInput from '@/FormulateInput.vue'
+
+Vue.use(Formulate)
+
+describe('FormulateSchema', () => {
+  it('renders a FormulateInput by default', async () => {
+    const wrapper = mount(FormulateSchema, { propsData: { schema: [
+      {}
+    ]}})
+    expect(wrapper.findComponent(FormulateInput).exists()).toBe(true)
+  })
+
+  it('it can render a standard div', async () => {
+    const wrapper = mount(FormulateSchema, { propsData: { schema: [
+      { component: 'div', class: 'test-div' }
+    ]}})
+    expect(wrapper.find('.test-div').exists()).toBe(true)
+  })
+
+  it('it can render children', async () => {
+    const wrapper = mount(FormulateSchema, { propsData: { schema: [
+      { component: 'div', class: 'test-div', children: [{}] }
+    ]}})
+    expect(wrapper.find('.test-div .formulate-input').exists()).toBe(true)
+  })
+
+  it('it can render children inside a group input', async () => {
+    const wrapper = mount(FormulateSchema, { propsData: { schema: [
+      { type: 'group', repeatable: true, children: [{}] }
+    ]}})
+    expect(wrapper.findAll('.formulate-input-grouping .formulate-input').length)
+      .toBe(1)
+    wrapper.find('.formulate-input-group-add-more button').trigger('click')
+    await flushPromises()
+    expect(wrapper.findAll('.formulate-input-grouping .formulate-input').length)
+      .toBe(2)
+  })
+})


### PR DESCRIPTION
In this PR:

You can now generate nested form and group structures using a simple arrays. This closes #89 and has a similar structure. Here's an example:

```vue
<FormulateForm
  :schema="schema"
/>
```

If you don't want it to be outside the context of a `form` you can use:

```vue
<FormulateSchema
  schema="schema"
>
```

The schema structure is an array of props:

```js
const schema = [
  {
    type: 'text',
    name: 'email'
    validation: 'required|email'
  },
  {
    type: 'password'
    name: 'password'
    validation: 'required|min:10'
  },
  {
    type: 'password'
    name: 'password_confirm'
    validation: 'required|confirm:password'
  },
  {
    type: 'group',
    name: 'address',
    children: [
      {
        type: 'text',
        name: 'street'
      },
      {
        type: 'text',
        name: 'city'
      }
    ]
  }
]
```