### PR TITLE
Feature/issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,10 +1,16 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Find a reproducible bug? Let the team know.
 title: ''
 labels: 'bug report'
 assignees: ''
 ---
+
+NOTE: If you have a question about how to use Vue Formulate, please do not file
+a bug report. Instead checkout the community page of the documentation for
+details on the best places to ask those questions.
+
+https://vueformulate.com/guide/community/
 
 **Describe the bug**
 A short description of what the bug is.
@@ -22,13 +28,13 @@ It's hugely helpful if you can isolate the bug in a CodePen or CodeSandbox. You 
 ### CodePen:
 CodePen is perfect for simple reproductions. Vue Formulate is already loaded and ready to use:
 
-[Reproduce in CodePen](https://codepen.io/boyd/pen/YzyJPor)
+https://codepen.io/boyd/pen/YzyJPor
 
 ### CodeSandbox
 
 This is better for occasions when you need to show issues with registering Vue Formulate or configuring base options.
 
-[Reproduce in CodeSandbox](https://codesandbox.io/s/vue-formulate-reproduction-template-p5c1i?file=/src/components/Reproduction.vue)
+https://codesandbox.io/s/vue-formulate-reproduction-template-p5c1i?file=/src/components/Reproduction.vue
 
 
 **Expected behavior**

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/src/libs/context.js
+++ b/src/libs/context.js
@@ -452,7 +452,7 @@ function modelGetter () {
   if (this.type === 'checkbox' && !Array.isArray(this[model]) && this.options) {
     return []
   }
-  if (!this[model]) {
+  if (!this[model] && this[model] !== 0) {
     return ''
   }
   return this[model]

--- a/test/unit/FormulateForm.test.js
+++ b/test/unit/FormulateForm.test.js
@@ -744,4 +744,25 @@ describe('FormulateForm', () => {
     expect(wrapper.vm.formData.test).toBe('2')
     expect(wrapper.vm.sameAsValue).toBe(true)
   })
+
+  it('properly hydrates when an initial value is zero', async () => {
+    const wrapper = mount({
+      template: `
+        <FormulateForm
+          v-model="formData"
+        >
+          <FormulateInput type="range" name="test" />
+        </FormulateForm>
+      `,
+      data () {
+        return {
+          formData: {
+            test: 0,
+          }
+        }
+      }
+    })
+    await flushPromises()
+    expect(wrapper.findComponent(FormulateInput).vm.context.model).toBe(0)
+  })
 })


### PR DESCRIPTION
In this PR:

- Updated issue template to refer back to new community documentation.
- Prevents blank issues. People must now use one of the 2 pre-existing issue templates.
- Also contains a small bugfix, but this wont be published yet