### PR TITLE
Add a modelHook on FormulateInput, available through FormulateForm's schema too

### DIFF
--- a/src/FormulateInput.vue
+++ b/src/FormulateInput.vue
@@ -244,7 +244,7 @@ export default {
     },
     modelHook: {
       type: Function,
-      default: (newModel, oldModel) => newModel
+      default: null
     }
   },
   data () {
@@ -310,7 +310,7 @@ export default {
     },
     'context.model': {
       handler (newModel, oldModel) {
-        if ((newModel !== oldModel && this.context.attributes.mask)) {
+        if (newModel !== oldModel && typeof this.modelHook === 'function') {
           this.context.model = this.modelHook(newModel, oldModel, { context: this.context })
         }
       }

--- a/src/FormulateInput.vue
+++ b/src/FormulateInput.vue
@@ -241,6 +241,10 @@ export default {
     addLabel: {
       type: [Boolean, String],
       default: false
+    },
+    modelHook: {
+      type: Function,
+      default: (newModel, oldModel) => newModel
     }
   },
   data () {
@@ -302,6 +306,13 @@ export default {
     formulateValue (newValue, oldValue) {
       if (this.isVmodeled && !shallowEqualObjects(newValue, oldValue)) {
         this.context.model = newValue
+      }
+    },
+    'context.model': {
+      handler (newModel, oldModel) {
+        if ((newModel !== oldModel && this.context.attributes.mask)) {
+          this.context.model = this.modelHook(newModel, oldModel, { context: this.context })
+        }
       }
     },
     showValidationErrors: {

--- a/src/FormulateInput.vue
+++ b/src/FormulateInput.vue
@@ -311,7 +311,7 @@ export default {
     'context.model': {
       handler (newModel, oldModel) {
         if (newModel !== oldModel && typeof this.modelHook === 'function') {
-          this.context.model = this.modelHook(newModel, oldModel, { context: this.context })
+          this.context.model = this.modelHook(newModel, { oldModel, context: this.context })
         }
       }
     },

--- a/test/unit/FormulateInput.test.js
+++ b/test/unit/FormulateInput.test.js
@@ -816,22 +816,6 @@ describe('FormulateInput', () => {
   })
 
   it('uses a modelHook to force output as number', async () => {
-    // const wrapper = mount({
-    //   data () {
-    //     return {
-    //       age: 35
-    //     }
-    //   },
-    //   methods: {
-    //     forceNumber(value){
-    //       console.log('value', value)
-    //       return +value
-    //     }
-    //   },
-    //   template: `
-    //     <FormulateInput type="number" v-model="age" :modelHook="forceNumber" />
-    //   `
-    // })
     const wrapper = mount(FormulateInput, { propsData: {
       type: 'number',
       value: 35,

--- a/test/unit/FormulateInput.test.js
+++ b/test/unit/FormulateInput.test.js
@@ -814,4 +814,33 @@ describe('FormulateInput', () => {
     await flushPromises()
     expect(wrapper.find('.formulate-errors').exists()).toBe(false)
   })
+
+  it('uses a modelHook to force output as number', async () => {
+    // const wrapper = mount({
+    //   data () {
+    //     return {
+    //       age: 35
+    //     }
+    //   },
+    //   methods: {
+    //     forceNumber(value){
+    //       console.log('value', value)
+    //       return +value
+    //     }
+    //   },
+    //   template: `
+    //     <FormulateInput type="number" v-model="age" :modelHook="forceNumber" />
+    //   `
+    // })
+    const wrapper = mount(FormulateInput, { propsData: {
+      type: 'number',
+      value: 35,
+      modelHook(value){
+        return +value
+      }
+    } })
+    wrapper.vm.context.model = "30"
+    await flushPromises()
+    expect(wrapper.vm.context.model).toBe(30)
+  })
 })


### PR DESCRIPTION
Would provide for #161 and #67.

I've implemented it as discussed. 
Also added tests cases on FormulateInput as well as FormulateForm, including some for both use cases stated above.

This should open a new road to build tiny utility plugins 😃

(Code is super simple. Tests should explain properly how to use it.)