### PR TITLE
Allow passing custom props to component in FormulateInput using slotProps.component

### DIFF
--- a/src/libs/context.js
+++ b/src/libs/context.js
@@ -421,7 +421,8 @@ function slotProps () {
     errors: fn(this.type, 'errors', this.typeProps),
     repeatable: fn(this.type, 'repeatable', this.typeProps),
     addMore: fn(this.type, 'addMore', this.typeProps),
-    remove: fn(this.type, 'remove', this.typeProps)
+    remove: fn(this.type, 'remove', this.typeProps),
+    component: fn(this.type, 'component', this.typeProps)
   }
 }
 


### PR DESCRIPTION
Not sure if there is a workaround and/or if this is intended, but if you want to pass on some custom properties for a FormulateInput to be passed on to the custom component, it doesn't seem to work.

The following reproduction code doesn't work with current implementation for example: https://codesandbox.io/s/issue-using-slotprops-on-component-sy5v5?file=/src/components/Reproduction.vue.

As always, I've made a fix within vue-formulate-extended for a quick support.
You can see the test case here:  https://github.com/gahabeen/vue-formulate-extended/blob/59c1716ebca76fc89d384d68cf59ff3ae26e91f6/tests/unit/features/FormulateInput.spec.js#L86-L91.

Hope it helps others too!