### PR TITLE
Fix remove file already uploaded

### DIFF
--- a/src/FileUpload.js
+++ b/src/FileUpload.js
@@ -89,7 +89,7 @@ class FileUpload {
    */
   uploaderIsAxios () {
     if (
-      this.hasUploader &&
+      this.hasUploader() &&
       typeof this.context.uploader.request === 'function' &&
       typeof this.context.uploader.get === 'function' &&
       typeof this.context.uploader.delete === 'function' &&
@@ -133,7 +133,7 @@ class FileUpload {
       return this.uploadPromise
     }
     this.uploadPromise = new Promise((resolve, reject) => {
-      if (!this.hasUploader) {
+      if (!this.hasUploader()) {
         return reject(new Error('No uploader has been defined'))
       }
       Promise.all(this.files.map(file => {

--- a/test/unit/FormulateInputFile.test.js
+++ b/test/unit/FormulateInputFile.test.js
@@ -121,6 +121,15 @@ describe('FormulateInputFile', () => {
     expect(wrapper.vm.context.model.files).toHaveLength(0)
   })
 
+  it('caches uploadPromise', async () => {
+    const wrapper = mount(FormulateInput, { propsData: { type: 'image', value: [ { url: 'https://via.placeholder.com/350x150.png' } ] } })
+    expect(wrapper.vm.context.model).toBeInstanceOf(FileUpload)
+    expect(wrapper.vm.context.model.upload()).toBeInstanceOf(Promise)
+    expect(wrapper.vm.context.model.upload()).toEqual(wrapper.vm.context.model.uploadPromise)
+    await flushPromises()
+    expect(wrapper.vm.context.model.uploadPromise).toBeNull();
+  })
+
   /**
    * ===========================================================================
    * Currently there appears to be no way to properly mock upload data in

--- a/test/unit/FormulateInputFile.test.js
+++ b/test/unit/FormulateInputFile.test.js
@@ -114,6 +114,13 @@ describe('FormulateInputFile', () => {
     expect(focus.mock.calls.length).toBe(1);
   })
 
+  it('removes a file from initial value', async () => {
+    const wrapper = mount(FormulateInput, { propsData: { type: 'image', value: [ { url: 'https://via.placeholder.com/350x150.png' } ] } })
+    expect(wrapper.vm.context.model.files).toHaveLength(1)
+    wrapper.vm.context.model.files[0].removeFile()
+    expect(wrapper.vm.context.model.files).toHaveLength(0)
+  })
+
   /**
    * ===========================================================================
    * Currently there appears to be no way to properly mock upload data in


### PR DESCRIPTION
Fixes #245
Fixes #288
Fixes #303

This regression is related to #270 and #271. After the uploadPromise caching was implemented, this cache was not being cleared after the removal of the file, resulting in Promise resolving with the outdated files. This is now fixed.
While debugging this problem, I found another one where Vue was firing a warning when removing files that have not yet been uploaded (`upload‑behavior=delayed`) or whose upload had failed. This was fixed too.

**Reproduction**
https://codepen.io/acemir/pen/bGeGaBV