### PR TITLE
Feature/form change event

### DIFF
--- a/src/FormulateForm.vue
+++ b/src/FormulateForm.vue
@@ -1,6 +1,7 @@
 <template>
   <form
     :class="classes"
+    @change="formChanged"
     @submit.prevent="formSubmitted"
   >
     <FormulateSchema
@@ -164,6 +165,10 @@ export default {
       if (!this.errorComponents.includes(component)) {
         this.errorComponents.push(component)
       }
+    },
+    formChanged () {
+      const submission = new FormSubmission(this)
+      this.$emit('change', submission)
     },
     formSubmitted () {
       if (this.submissionPromise) {

--- a/test/unit/FormulateForm.test.js
+++ b/test/unit/FormulateForm.test.js
@@ -253,6 +253,17 @@ describe('FormulateForm', () => {
     expect(wrapper.emitted('submit-raw')[0][0]).toBeInstanceOf(FormSubmission)
   })
 
+  it('emits an instance of FormSubmission on change', async () => {
+    const wrapper = mount(FormulateForm, {
+      slots: { default: `<FormulateInput type="text" validation="required|in:bar" name="testinput" />` }
+    })
+    const input = wrapper.find('input[type="text"]')
+    input.setValue('foo')
+    input.trigger('change')
+    await flushPromises()
+    expect(wrapper.emitted('change')[0][0]).toBeInstanceOf(FormSubmission)
+  })
+
   it('resolves hasValidationErrors to true', async () => {
     const wrapper = mount(FormulateForm, {
       slots: { default: '<FormulateInput type="text" validation="required" name="testinput" />' }

--- a/test/unit/FormulateForm.test.js
+++ b/test/unit/FormulateForm.test.js
@@ -1,5 +1,5 @@
 import Vue from 'vue'
-import { mount, shallowMount } from '@vue/test-utils'
+import { mount } from '@vue/test-utils'
 import flushPromises from 'flush-promises'
 import Formulate from '../../src/Formulate.js'
 import FormSubmission from '../../src/FormSubmission.js'

--- a/test/unit/FormulateForm.test.js
+++ b/test/unit/FormulateForm.test.js
@@ -264,6 +264,17 @@ describe('FormulateForm', () => {
     expect(wrapper.emitted('change')[0][0]).toBeInstanceOf(FormSubmission)
   })
 
+  it('emits a single event on Form input', async () => {
+    const wrapper = mount(FormulateForm, {
+      slots: { default: `<FormulateInput type="text" validation="required|in:bar" name="testinput" />` }
+    })
+    const input = wrapper.find('input[type="text"]')
+    input.setValue('foo')
+    input.trigger('input')
+    await flushPromises()
+    expect(wrapper.emitted('input').length).toBe(1)
+  })
+
   it('resolves hasValidationErrors to true', async () => {
     const wrapper = mount(FormulateForm, {
       slots: { default: '<FormulateInput type="text" validation="required" name="testinput" />' }


### PR DESCRIPTION
I am building a form builder that allows users to connect actions to inputs. Without the form emitting its `change` events, there is no way for me to react to updates in the form without relying on native DOM event listeners. Not ideal.

This PR just adds `onChange` to the top level `form` element so when any of the children fire `change` the top level form can emit those changes.