### PR TITLE
Adds support for prefix and sufix

### DIFF
--- a/examples/specimens/SpecimenSlider.vue
+++ b/examples/specimens/SpecimenSlider.vue
@@ -13,7 +13,7 @@
       />
     </div>
     <div class="specimen">
-      <h3>Range with Prefix and Sufix</h3>
+      <h3>Range with Prefix and Suffix</h3>
       <FormulateInput
         label="How much time do you spend coding per day?"
         type="range"
@@ -22,7 +22,7 @@
         step="10"
         value="20"
         prefix="~"
-        sufix="%"
+        suffix="%"
         :show-value="true"
         help="Around..."
       />

--- a/examples/specimens/SpecimenSlider.vue
+++ b/examples/specimens/SpecimenSlider.vue
@@ -12,5 +12,20 @@
         help="Whenever we’re allowed to have a party again..."
       />
     </div>
+    <div class="specimen">
+      <h3>Range with Prefix and Sufix</h3>
+      <FormulateInput
+        label="How much time do you spend coding per day?"
+        type="range"
+        min="0"
+        max="100"
+        step="10"
+        value="20"
+        prefix="~"
+        sufix="%"
+        :show-value="true"
+        help="Around..."
+      />
+    </div>
   </div>
 </template>

--- a/src/FormulateInput.vue
+++ b/src/FormulateInput.vue
@@ -40,6 +40,8 @@
           :is="context.component"
           :context="context"
           v-bind="context.slotProps.component"
+          :sufix="sufix"
+          :prefix="prefix"
           v-on="listeners"
         >
           <slot v-bind="context" />
@@ -227,6 +229,14 @@ export default {
     showValue: {
       type: [String, Boolean],
       default: false
+    },
+    prefix: {
+      type: [String],
+      default: ''
+    },
+    sufix: {
+      type: [String],
+      default: ''
     },
     validationMessages: {
       type: Object,

--- a/src/FormulateInput.vue
+++ b/src/FormulateInput.vue
@@ -40,7 +40,7 @@
           :is="context.component"
           :context="context"
           v-bind="context.slotProps.component"
-          :sufix="sufix"
+          :suffix="suffix"
           :prefix="prefix"
           v-on="listeners"
         >
@@ -234,7 +234,7 @@ export default {
       type: [String],
       default: ''
     },
-    sufix: {
+    suffix: {
       type: [String],
       default: ''
     },

--- a/src/inputs/FormulateInputSlider.vue
+++ b/src/inputs/FormulateInputSlider.vue
@@ -14,7 +14,7 @@
       v-if="context.showValue"
       :class="context.classes.rangeValue"
     >
-      {{ prefix }}{{ context.model }}{{ sufix }}
+      {{ prefix }}{{ context.model }}{{ suffix }}
     </div>
   </div>
 </template>
@@ -30,7 +30,7 @@ export default {
       type: [String],
       default: ''
     },
-    sufix: {
+    suffix: {
       type: [String],
       default: ''
     }

--- a/src/inputs/FormulateInputSlider.vue
+++ b/src/inputs/FormulateInputSlider.vue
@@ -13,8 +13,9 @@
     <div
       v-if="context.showValue"
       :class="context.classes.rangeValue"
-      v-text="context.model"
-    />
+    >
+      {{ prefix }}{{ context.model }}{{ sufix }}
+    </div>
   </div>
 </template>
 
@@ -23,6 +24,16 @@ import FormulateInputMixin from '../FormulateInputMixin'
 
 export default {
   name: 'FormulateInputSlider',
-  mixins: [FormulateInputMixin]
+  mixins: [FormulateInputMixin],
+  props: {
+    prefix: {
+      type: [String],
+      default: ''
+    },
+    sufix: {
+      type: [String],
+      default: ''
+    }
+  }
 }
 </script>


### PR DESCRIPTION
@justin-schroeder this might not be the best way to implement this, but it adds some simple props to add suffix and prefix.

Usage is to add for example `%` sign to the end of the sliders displayed value, but I thik it can find additional usage on other input types as well.