### PR TITLE
Make index available in remove slot component

### DIFF
--- a/src/slots/FormulateRepeatable.vue
+++ b/src/slots/FormulateRepeatable.vue
@@ -10,6 +10,7 @@
       <component
         :is="context.slotComponents.remove"
         :context="context"
+        :index="index"
         :remove-item="removeItem"
         v-bind="context.slotProps.remove"
       />

--- a/src/slots/FormulateRepeatableRemove.vue
+++ b/src/slots/FormulateRepeatableRemove.vue
@@ -12,6 +12,10 @@
 <script>
 export default {
   props: {
+    index: {
+      type: Number,
+      default: null
+    },
     context: {
       type: Object,
       required: true

--- a/test/unit/FormulateInputGroup.test.js
+++ b/test/unit/FormulateInputGroup.test.js
@@ -6,6 +6,7 @@ import FileUpload from '@/FileUpload.js'
 import FormulateInput from '@/FormulateInput.vue'
 import FormulateForm from '@/FormulateForm.vue'
 import FormulateGrouping from '@/FormulateGrouping.vue'
+import FormulateRepeatableRemove from '@/slots/FormulateRepeatableRemove.vue'
 import FormulateRepeatableProvider from '@/FormulateRepeatableProvider.vue'
 
 Vue.use(Formulate)
@@ -502,6 +503,22 @@ describe('FormulateInputGroup', () => {
     expect(repeatables.length).toBe(2)
     expect(repeatables.at(0).text()).toBe('test-0')
     expect(repeatables.at(1).text()).toBe('test-1')
+  })
+
+  it('exposes the index to the remove slot', async () => {
+    const wrapper = mount({
+      template: `
+        <FormulateInput
+          type="group"
+          name="test"
+          :value="[{}, {}]"
+        >
+        </FormulateInput>
+      `,
+    })
+    const removes = wrapper.findAllComponents(FormulateRepeatableRemove)
+    expect(removes.at(0).vm.index).toBe(0)
+    expect(removes.at(1).vm.index).toBe(1)
   })
 
   it('forces non-repeatable groups to not initialize with an empty array', async () => {


### PR DESCRIPTION
Exposes the item index to the remove slot component so it can be used to set aria-labels, such as "remove item 1". 

See: https://github.com/wearebraid/vue-formulate/issues/294