### PR TITLE
Forward map's index to avoid key colliding

### DIFF
--- a/src/FormulateSchema.js
+++ b/src/FormulateSchema.js
@@ -29,8 +29,8 @@ export function leaf (item, index) {
  */
 function tree (h, schema) {
   if (Array.isArray(schema)) {
-    return schema.map(el => {
-      const item = leaf(el)
+    return schema.map((el, i) => {
+      const item = leaf(el, i)
       return h(
         item.component,
         { attrs: item.attrs, class: item.class, key: item.key },


### PR DESCRIPTION
It avoids generating multiple keys like 'el-1-undefined'