### PR TITLE
Fix shallowEqualObjects doesn't consider numbers 

### DIFF
--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -26,6 +26,11 @@ export function shallowEqualObjects (objA, objB) {
   if (!objA || !objB) {
     return false
   }
+
+  if (typeof objA === 'number' && typeof objB === 'number') {
+    return objA === objB
+  }
+
   var aKeys = Object.keys(objA)
   var bKeys = Object.keys(objB)
   var len = aKeys.length


### PR DESCRIPTION
**Describe the bug**
Form values doesn't change when input reactive variable has type **number**

**To Reproduce**
Steps to reproduce the behavior:
1. Go to [Sandbox](https://codesandbox.io/s/vue-formulate-reproduction-template-forked-0i7kq?file=/package.json:249-254)
2. Click on *Set form data to random float*, that sets `form.number` variable to random number

**ER**: 
- Input sets to new random value,

**AR**:
- Input form doesn't change. It changes when we click on "Input sets to new random value string" that sets **form.number** to string type

This issue happened when I extend formulate library to use custom dropdown that use context.model with Number type. And as a result when form updates with new dropdown value somewhere outside the FormulateInput component - it doesn't change

**Reproduction**
https://codesandbox.io/s/vue-formulate-reproduction-template-forked-0i7kq?file=/src/components/Reproduction.vue:61-75

