### PR TITLE
Priority change for validation name

### DIFF
--- a/src/libs/context.js
+++ b/src/libs/context.js
@@ -264,11 +264,11 @@ function mergedValidationName () {
   if (this.validationName) {
     return this.validationName
   }
-  if (typeof this.name === 'string') {
-    return this.name
-  }
   if (this.label) {
     return this.label
+  }
+  if (typeof this.name === 'string') {
+    return this.name
   }
   return this.type
 }


### PR DESCRIPTION
The label attribute is more readable than the name as field reference for a validation error.
Often the input attribute names have tecnical meaning instead of "user readable name".
For example, in my case, in italy always the field names are defined in english, but the labels are often in italian, and this cause that an error validation doesn't refer to the italian label but to a tecnical english name.
Otherwise, if this change is a breaking change, I suggest to manage this kind of priority change via an global configuration, to prevent to define each time the "validation-name" as the label.