### PR TITLE
Added route to class context

### DIFF
--- a/src/libs/context.js
+++ b/src/libs/context.js
@@ -217,6 +217,7 @@ function classes () {
       helpPosition: this.logicalHelpPosition,
       isValid: this.isValid,
       labelPosition: this.logicalLabelPosition,
+      route: this.$route,
       type: this.type,
       value: this.proxy
     }


### PR DESCRIPTION
When customizing classes globally it can be helpful to set default classes based on the current route for example: `route.path.startsWith(...)` or `route.path === '...'`. This allows you to have more than one set of default classes and even themes through `route.meta.theme` for example.