### PR TITLE
Fix unit test on before validation rule

### DIFF
--- a/test/unit/rules.test.js
+++ b/test/unit/rules.test.js
@@ -112,7 +112,7 @@ describe('before', () => {
 
   it('passes with old date string', async () => expect(await rules.before({ value: 'January, 2000' })).toBe(true))
 
-  it('fails with invalid value', async () => expect(await rules.after({ value: '' })).toBe(false))
+  it('fails with invalid value', async () => expect(await rules.before({ value: '' })).toBe(false))
 })
 
 /**


### PR DESCRIPTION
This looks like it had accidentally not been changed after a copy-paste: the test group is for `before`, not `after`.